### PR TITLE
Remove dependency on jq

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ beautifulsoup4==4.12.3
 dateparser==1.2.0
 emoji==2.12.1
 html2text==2024.2.26
-jq==1.7.0
 puzpy==0.2.6
 requests==2.32.3
 Unidecode==1.3.8


### PR DESCRIPTION
jq was used in a single line for filtering JSON, but this can be done easily in Python and avoids adding a dependency.